### PR TITLE
refactor: move scroll ID to body param

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -310,7 +310,9 @@ class Connection extends BaseConnection
         while (!$limit || $numResults < $limit) {
             // Execute a Scroll request
             $results = $this->connection->scroll([
-                'scroll_id' => $scrollId,
+                'body' => [
+                    'scroll_id' => $scrollId,
+                ],
                 'scroll' => $scrollTimeout,
             ]);
 


### PR DESCRIPTION
Deprecation notice:
https://github.com/elastic/elasticsearch-php/blob/6ad129d5d84b9b083e927f5ac5b417ff00de7f7e/src/Elasticsearch/Endpoints/Scroll.php#L36

FYI @StevePorter92 