### PR TITLE
refactor: better query debug

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -248,6 +248,33 @@ class Connection extends BaseConnection
     }
 
     /**
+     * @return array
+     */
+    public function getQueryLogJson(): array
+    {
+        return array_map(
+            function ($log) {
+                return str_replace('    ', '  ', json_encode($log['query']['body'], JSON_PRETTY_PRINT));
+            },
+            $this->getQueryLog()
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function dumpQueryLogJson(): void
+    {
+        print '<pre>';
+
+        foreach ($this->getQueryLogJson() as $query) {
+            print $query . "\n\n";
+        }
+
+        print '</pre>';
+    }
+
+    /**
      * Prepare the query bindings for execution.
      *
      * @param array $bindings

--- a/src/QueryGrammar.php
+++ b/src/QueryGrammar.php
@@ -65,10 +65,6 @@ class QueryGrammar extends BaseGrammar
             unset($params['body']['query']);
         }
 
-        // print "<pre>";
-        // print str_replace('    ', '  ', json_encode($params, JSON_PRETTY_PRINT));
-        // exit;
-
         return $params;
     }
 


### PR DESCRIPTION
@trybeapp/tech FYI in case you were used to going to QueryGrammar and hackily un-commenting the `print_r` there, like I was 😳 . New way:

```
\Illuminate\Support\Facades\DB::connection('elasticsearch')->enableQueryLog();
...
\Illuminate\Support\Facades\DB::connection('elasticsearch')-> dumpQueryLogJson();
```

This will print all logged queries in JSON format that can be posted directly to Elasticsearch for debugging.