### PR TITLE
feat: support additional options for match query

### DIFF
--- a/src/QueryGrammar.php
+++ b/src/QueryGrammar.php
@@ -514,19 +514,17 @@ class QueryGrammar extends BaseGrammar
                 'match' => [
                     $field => [
                         'query' => $where['value'],
-                    ]
+                    ],
                 ],
             ];
         }
 
-        if (! empty($where['options']['fuzziness'])) {
-            $matchType = array_keys($query)[0];
+        $matchType = array_keys($query)[0];
 
-            if ($matchType === 'multi_match') {
-                $query[$matchType]['fuzziness'] = $where['options']['fuzziness'];
-            } else {
-                $query[$matchType][$field]['fuzziness'] = $where['options']['fuzziness'];
-            }
+        if (! empty($where['options']['fuzziness']) && $matchType === 'multi_match') {
+            $query[$matchType]['fuzziness'] = $where['options']['fuzziness'];
+        } elseif (! empty($where['options']['fuzziness'])) {
+            $query[$matchType][$field]['fuzziness'] = $where['options']['fuzziness'];
         }
 
         if (! empty($where['options']['constant_score'])) {
@@ -535,6 +533,17 @@ class QueryGrammar extends BaseGrammar
                     'query' => $query,
                 ],
             ];
+        }
+
+        $otherOptions = array_diff_key(
+            $where['options'],
+            array_flip(['fields', 'fuzziness', 'constant_score'])
+        );
+
+        if ($matchType === 'multi_match') {
+            $query['multi_match'] = $query['multi_match'] + $otherOptions;
+        } else {
+            $query[$matchType][$field] = $query[$matchType][$field] + $otherOptions;
         }
 
         return $query;
@@ -997,19 +1006,12 @@ class QueryGrammar extends BaseGrammar
     {
         $metric = $aggregation['type'];
 
-        if (is_array($aggregation['args'])) {
-            $args = array_filter([
-                'field' => $aggregation['args']['field'] ?? null,
-                'script' => $aggregation['args']['script'] ?? null,
-            ]);
-        } else {
-            $args = [
-                'field' => $aggregation['args'],
-            ];
-        }
+        $field = is_array($aggregation['args']) ? $aggregation['args']['field'] : $aggregation['args'];
 
         return [
-            $metric => $args,
+            $metric => [
+                'field' => $field
+            ]
         ];
     }
 

--- a/src/QueryGrammar.php
+++ b/src/QueryGrammar.php
@@ -1006,12 +1006,19 @@ class QueryGrammar extends BaseGrammar
     {
         $metric = $aggregation['type'];
 
-        $field = is_array($aggregation['args']) ? $aggregation['args']['field'] : $aggregation['args'];
+        if (is_array($aggregation['args'])) {
+            $args = array_filter([
+                'field' => $aggregation['args']['field'] ?? null,
+                'script' => $aggregation['args']['script'] ?? null,
+            ]);
+        } else {
+            $args = [
+                'field' => $aggregation['args'],
+            ];
+        }
 
         return [
-            $metric => [
-                'field' => $field
-            ]
+            $metric => $args,
         ];
     }
 


### PR DESCRIPTION
The options 'fields', 'fuzziness' and 'constant_score' are added separately; this will include any other options that are passed to the method. Immediate requirement is to be able to pass `boost`.