### PR TITLE
refactor: avoid extra query for count

### DIFF
--- a/src/EloquentBuilder.php
+++ b/src/EloquentBuilder.php
@@ -138,7 +138,7 @@ class EloquentBuilder extends BaseBuilder
 
         $results = $this->forPage($page, $perPage)->get($columns);
 
-        $total = $this->toBase()->getCountForPagination($columns);
+        $total = $this->query->getProcessor()->getRawResponse()['hits']['total']['value'];
 
         return new LengthAwarePaginator($results, $total, $perPage, $page, [
             'path'     => Paginator::resolveCurrentPath(),


### PR DESCRIPTION
I've known for a while that when paginating in ES we end up making two queries - one for the results and another with a limit of 1 for the count.

Laravel's base class has a 'getCountForPagination' method that would do this in SQL, which this library overrides. That method tries to only re-run the query if `$this->results` is null but because of the way Laravel creates a new query when it applies scopes, that value is always null when checking here.

We can always rely on the raw results being available here so this is a much more efficient method.