### PR TITLE
fix: pass connection to QueryGrammar

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -596,7 +596,7 @@ class Connection extends BaseConnection
      */
     protected function getDefaultQueryGrammar()
     {
-        return $this->withIndexSuffix(new QueryGrammar);
+        return $this->withIndexSuffix(new QueryGrammar($this));
     }
 
     /**


### PR DESCRIPTION
The signature for the constructor in `Illuminate\Database\Grammar` [changed with Laravel 12](https://github.com/laravel/framework/pull/54487), and now requires `Illuminate\Database\Connection` to be passed in.