### PR TITLE
Replace query bindings before logging

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -235,7 +235,7 @@ class Connection extends BaseConnection
     /**
      * Log a query in the connection's query log.
      *
-     * @param string     $query
+     * @param array      $query
      * @param array      $bindings
      * @param float|null $time
      *
@@ -243,11 +243,75 @@ class Connection extends BaseConnection
      */
     public function logQuery($query, $bindings, $time = null)
     {
+        $query = $this->replaceQueryBindings($query);
+
         $this->event(new QueryExecuted(json_encode($query), $bindings, $time, $this));
 
         if ($this->loggingQueries) {
             $this->queryLog[] = compact('query', 'bindings', 'time');
         }
+    }
+
+    /**
+     * Replace values inside the query body with '?' for safe logging, leaving all
+     * other top-level query parameters (index, size, scroll, etc.) untouched.
+     *
+     * @param array $query
+     *
+     * @return array
+     */
+    protected function replaceQueryBindings(array $query): array
+    {
+        if (isset($query['body'])) {
+            $query['body'] = $this->replaceBodyValues($query['body']);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Recursively replace leaf values with '?' while preserving:
+     * - Field names in DSL clauses (e.g. {"exists": {"field": "some_field"}})
+     * - The _source array (field projection, not user data)
+     * - The _index value inside bulk action descriptors
+     *
+     * @param mixed       $value
+     * @param string|null $parentKey
+     *
+     * @return mixed
+     */
+    protected function replaceBodyValues(mixed $value, ?string $parentKey = null): mixed
+    {
+        $fieldNameKeys = ['field', 'fields', 'path', 'default_field'];
+        $bulkActionKeys = ['index', 'create', 'update', 'delete'];
+
+        if ($parentKey === '_source') {
+            return $value;
+        }
+
+        $isFieldNameKey = $parentKey !== null && in_array($parentKey, $fieldNameKeys, true);
+
+        if (!is_array($value)) {
+            return $isFieldNameKey ? $value : '?';
+        }
+
+        if ($isFieldNameKey) {
+            return array_map(fn ($v) => is_array($v) ? $this->replaceBodyValues($v) : $v, $value);
+        }
+
+        if ($parentKey !== null && in_array($parentKey, $bulkActionKeys, true)) {
+            foreach ($value as $k => $v) {
+                $value[$k] = $k === '_index' ? $v : (is_array($v) ? $this->replaceBodyValues($v, $k) : '?');
+            }
+
+            return $value;
+        }
+
+        foreach ($value as $k => $v) {
+            $value[$k] = $this->replaceBodyValues($v, (string) $k);
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/Unit/Elasticsearch/ConnectionTest.php
+++ b/tests/Unit/Elasticsearch/ConnectionTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Tests\Unit\Elasticsearch;
+
+use DesignMyNight\Elasticsearch\Connection;
+use Tests\TestCase;
+
+class ConnectionTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = new class extends Connection
+        {
+            public function __construct()
+            {
+                // Skip the real constructor to avoid requiring an Elasticsearch server
+            }
+
+            public function replaceQueryBindings(array $query): array
+            {
+                return parent::replaceQueryBindings($query);
+            }
+        };
+    }
+
+    /** @test */
+    public function it_only_replaces_values_inside_the_body(): void
+    {
+        $query = [
+            'index' => 'basket_items',
+            'size' => 10000,
+            'body' => [
+                'query' => [
+                    'term' => ['status' => 'active'],
+                ],
+            ],
+        ];
+
+        $result = $this->connection->replaceQueryBindings($query);
+
+        $this->assertEquals('basket_items', $result['index']);
+        $this->assertEquals(10000, $result['size']);
+        $this->assertEquals('?', $result['body']['query']['term']['status']);
+    }
+
+    /** @test */
+    public function it_preserves_field_names_in_dsl_clauses(): void
+    {
+        $query = [
+            'index' => 'basket_items',
+            'body' => [
+                'query' => [
+                    'bool' => [
+                        'must_not' => [
+                            ['exists' => ['field' => 'deleted_at']],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $result = $this->connection->replaceQueryBindings($query);
+
+        $this->assertEquals('deleted_at', $result['body']['query']['bool']['must_not'][0]['exists']['field']);
+    }
+
+    /** @test */
+    public function it_preserves_the_source_projection(): void
+    {
+        $query = [
+            'index' => 'basket_items',
+            'body' => [
+                '_source' => ['_id', 'status', 'created_at'],
+                'query' => [
+                    'term' => ['booking_id' => '69b18289d4cf42fc8f05f9d3'],
+                ],
+            ],
+        ];
+
+        $result = $this->connection->replaceQueryBindings($query);
+
+        $this->assertEquals(['_id', 'status', 'created_at'], $result['body']['_source']);
+        $this->assertEquals('?', $result['body']['query']['term']['booking_id']);
+    }
+
+    /** @test */
+    public function it_replaces_term_query_values(): void
+    {
+        $query = [
+            'index' => 'basket_items',
+            'body' => [
+                '_source' => ['_id'],
+                'query' => [
+                    'bool' => [
+                        'must' => [
+                            ['term' => ['booking_id' => '69b18289d4cf42fc8f05f9d3']],
+                            [
+                                'bool' => [
+                                    'must_not' => [
+                                        ['exists' => ['field' => 'deleted_at']],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'size' => 10000,
+            ],
+        ];
+
+        $result = $this->connection->replaceQueryBindings($query);
+
+        $this->assertEquals(['_id'], $result['body']['_source']);
+        $this->assertEquals('?', $result['body']['query']['bool']['must'][0]['term']['booking_id']);
+        $this->assertEquals('deleted_at', $result['body']['query']['bool']['must'][1]['bool']['must_not'][0]['exists']['field']);
+        $this->assertEquals('?', $result['body']['size']);
+    }
+
+    /** @test */
+    public function it_preserves_index_name_in_bulk_action_descriptors(): void
+    {
+        $query = [
+            'body' => [
+                ['index' => ['_index' => 'basket_items', '_id' => '69de087897e4a0f5640da224']],
+                ['id' => '69de087897e4a0f5640da224', 'status' => 'cancelled', 'price' => 4000],
+            ],
+        ];
+
+        $result = $this->connection->replaceQueryBindings($query);
+
+        $this->assertEquals('basket_items', $result['body'][0]['index']['_index']);
+        $this->assertEquals('?', $result['body'][0]['index']['_id']);
+    }
+
+    /** @test */
+    public function it_replaces_document_field_values_in_bulk_body(): void
+    {
+        $query = [
+            'body' => [
+                ['index' => ['_index' => 'basket_items', '_id' => '69de087897e4a0f5640da224']],
+                [
+                    'id' => '69de087897e4a0f5640da224',
+                    'status' => 'cancelled',
+                    'price' => 4000,
+                    'customer' => ['first_name' => 'Test', 'email' => 'test@example.com'],
+                ],
+            ],
+        ];
+
+        $result = $this->connection->replaceQueryBindings($query);
+
+        $document = $result['body'][1];
+
+        $this->assertEquals('?', $document['id']);
+        $this->assertEquals('?', $document['status']);
+        $this->assertEquals('?', $document['price']);
+        $this->assertEquals('?', $document['customer']['first_name']);
+        $this->assertEquals('?', $document['customer']['email']);
+    }
+
+    /** @test */
+    public function it_returns_query_unchanged_when_there_is_no_body(): void
+    {
+        $query = ['index' => 'basket_items', 'scroll_id' => 'abc123'];
+
+        $result = $this->connection->replaceQueryBindings($query);
+
+        $this->assertEquals($query, $result);
+    }
+}


### PR DESCRIPTION
This change makes the `QueryExecuted` event handle the query the same as regular Eloquent does. That is to log the query with `?` parameters rather than the raw values.

Useful in Laravel Nightwatch to actually collect metrics on query shape rather than specific queries. Also prevents leaking potentially PII into monitoring services.