### PR TITLE
Drop all tables

### DIFF
--- a/src/Database/Schema/ElasticsearchBuilder.php
+++ b/src/Database/Schema/ElasticsearchBuilder.php
@@ -35,6 +35,7 @@ class ElasticsearchBuilder extends Builder
         }));
     }
 
+    #[\Override]
     public function dropAllTables()
     {
         collect($this->connection->indices()->get(['index' => '*'])->asArray())->keys()->each(function (string $index) {

--- a/src/Database/Schema/ElasticsearchBuilder.php
+++ b/src/Database/Schema/ElasticsearchBuilder.php
@@ -3,11 +3,13 @@
 namespace DesignMyNight\Elasticsearch\Database\Schema;
 
 use Closure;
+use DesignMyNight\Elasticsearch\Connection;
 use Illuminate\Database\Schema\Builder;
 
 /**
  * Class Builder
  * @package DesignMyNight\Elasticsearch\Database\Schema
+ * @property Connection $connection
  */
 class ElasticsearchBuilder extends Builder
 {
@@ -31,6 +33,13 @@ class ElasticsearchBuilder extends Builder
 
             $callback($blueprint);
         }));
+    }
+
+    public function dropAllTables()
+    {
+        collect($this->connection->indices()->get(['index' => '*'])->asArray())->keys()->each(function (string $index) {
+            $this->connection->indices()->delete(compact('index'));
+        });
     }
 
     /**


### PR DESCRIPTION
This add the `dropAllTables()` method to the builder, this is so that the Elasticsearch database connection integrates with Laravels `php artisan db:wipe --database elasticsearch` command.

This should make resetting ES locally easier.